### PR TITLE
Up down traversal

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -17,6 +17,7 @@ Allows you to receive notification center notifications for new messages, and ad
 | Start a new conversation                       | ⌘N        |
 | Search past conversations                      | ⌘F        |
 | Jump to your 1st .. 9th most recent converation| ⌘1 .. ⌘9  |
+| Scroll through your conversations              | ↑ and ↓   |
 
 Inspired by, and in small part based on, [Messenger for Mac](http://fbmacmessenger.rsms.me/), created by [Rasmus Andersson](https://twitter.com/rsms). ChitChat uses some code from this project.
 

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -82,6 +82,13 @@ jQuery(function () {
                     var $desiredItem = direction === 'UP' ? $selectedItem.prev() : $selectedItem.next();
                     if ($desiredItem.length > 0) {
                         $desiredItem[0].firstChild.click();
+                        // Gets the CSS transformY value
+                        var scrollPos = parseInt($($desiredItem[0])
+                                            .css('transform')
+                                            .split(',')
+                                            .slice()
+                                            .pop());
+                        $('.pane-list-body')[0].scrollTop = scrollPos;
                     }
                 }
             }

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -51,3 +51,40 @@ function setActiveConversationAtIndex(index) {
     }
     conversationList.scrollTop = 0;
 }
+
+jQuery(function () {
+    (function ($) {
+        $(document).keydown(function (event) {
+            var direction = null;
+            switch (event.which) {
+                case 38:
+                    direction = 'UP';
+                    break;
+                case 40:
+                    direction = 'DOWN';
+                    break;
+                default:
+                    break;
+            }
+            var $input = $('.input');
+            var isInputFieldEmpty = $input.contents().length === 0 ||
+                                    $input.contents()[0].nodeName === 'BR';
+            if (direction && isInputFieldEmpty) {
+                var $selectedItem = null;
+                $.each($('.infinite-list-viewport .infinite-list-item'), function (index, value) {
+                    var $this = $(this);
+                    if ($this.children('.chat').hasClass('active')) {
+                        $selectedItem = $this;
+                        return false;
+                    }
+                });
+                if ($selectedItem) {
+                    var $desiredItem = direction === 'UP' ? $selectedItem.prev() : $selectedItem.next();
+                    if ($desiredItem.length > 0) {
+                        $desiredItem[0].firstChild.click();
+                    }
+                }
+            }
+        });
+    })(jQuery);
+});


### PR DESCRIPTION
Using the ↑ and ↓ arrow keys when the input field is empty will artificially trigger a click on the next/previous chat and bring them into focus. 