### PR TITLE
Notification Enhancements & Fixes (Undraggable Window, Scrolling, etc)

### DIFF
--- a/WhatsMac/AppDelegate.h
+++ b/WhatsMac/AppDelegate.h
@@ -1,7 +1,7 @@
 #import <Cocoa/Cocoa.h>
 
-@interface AppDelegate : NSResponder <NSApplicationDelegate>
-@property(readonly) NSWindow* window;
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
 - (void)setActiveConversationAtIndex:(NSString*)index;
 - (BOOL)shouldPropagateMouseUpEvent:(NSEvent*)theEvent;
 - (BOOL)shouldPropagateMouseDownEvent:(NSEvent*)theEvent;

--- a/WhatsMac/AppDelegate.h
+++ b/WhatsMac/AppDelegate.h
@@ -4,7 +4,6 @@
 
 - (void)setActiveConversationAtIndex:(NSString*)index;
 - (BOOL)shouldPropagateMouseUpEvent:(NSEvent*)theEvent;
-- (BOOL)shouldPropagateMouseDownEvent:(NSEvent*)theEvent;
 - (BOOL)shouldPropagateMouseDraggedEvent:(NSEvent*)theEvent;
 
 @end

--- a/WhatsMac/AppDelegate.h
+++ b/WhatsMac/AppDelegate.h
@@ -1,8 +1,11 @@
 #import <Cocoa/Cocoa.h>
 
-@interface AppDelegate : NSObject <NSApplicationDelegate>
-
+@interface AppDelegate : NSResponder <NSApplicationDelegate>
+@property(readonly) NSWindow* window;
 - (void)setActiveConversationAtIndex:(NSString*)index;
+- (BOOL)shouldPropagateMouseUpEvent:(NSEvent*)theEvent;
+- (BOOL)shouldPropagateMouseDownEvent:(NSEvent*)theEvent;
+- (BOOL)shouldPropagateMouseDraggedEvent:(NSEvent*)theEvent;
 
 @end
 

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -245,6 +245,9 @@
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    if ([[self window] isMainWindow]) {
+        return;
+    }
     NSArray *messageBody = message.body;
     NSUserNotification *notification = [NSUserNotification new];
     notification.title = messageBody[0];
@@ -253,14 +256,18 @@
     [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:notification];
 }
 
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification {
+    return YES;
+}
+
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
     [self.webView evaluateJavaScript:
      [NSString stringWithFormat:@"openChat(\"%@\")", notification.identifier]
-                   completionHandler:nil];
+        completionHandler:nil];
     [center removeDeliveredNotification:notification];
 }
 
-- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)())completionHandler {
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler {
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = @"Uploading Media";
     alert.informativeText = message;

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -61,6 +61,7 @@
                                           styleMask:windowStyleFlags
                                             backing:NSBackingStoreBuffered
                                               defer:YES];
+    [_window center];
     _window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantLight];
     _window.titleVisibility = NSWindowTitleHidden;
     _window.titlebarAppearsTransparent = YES;
@@ -69,8 +70,7 @@
     _window.delegate = self;
     _window.frameAutosaveName = @"main";
     _window.collectionBehavior = NSWindowCollectionBehaviorFullScreenPrimary;
-    [_window center];
-    
+  
     _titlebarView = [_window standardWindowButton:NSWindowCloseButton].superview;
     [self updateWindowTitlebar];
     

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -98,16 +98,6 @@
 }
 
 - (BOOL)shouldPropagateMouseDownEvent:(NSEvent *)theEvent {
-  if( ![theEvent.window isEqual:_window] ) {
-    return YES;
-  }
-  
-  if( theEvent.locationInWindow.y < (_window.frame.size.height - 59) ) {
-    return YES;
-  }
-  
-  _initialDragPosition = theEvent.locationInWindow;
-  
   return YES;
 }
 
@@ -116,12 +106,13 @@
     return YES;
   }
   
-  if( theEvent.locationInWindow.y < (_window.frame.size.height - 59) ) {
-    return YES;
-  }
-
   if( !_isDragging ) {
     _isDragging = YES;
+    _initialDragPosition = theEvent.locationInWindow;
+  }
+  
+  if( _initialDragPosition.y < (_window.frame.size.height - 59) ) {
+    return YES;
   }
   
   NSPoint mouseLocation = [NSEvent mouseLocation];

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -3,7 +3,6 @@
 #import "WAMWebView.h"
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
-#import "WAMWindow.h"
 
 @import WebKit;
 @import Sparkle;
@@ -58,7 +57,7 @@
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     NSInteger windowStyleFlags = NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask | NSFullSizeContentViewWindowMask;
     _notificationCount = @"";
-    _window = [[WAMWindow alloc] initWithContentRect:CGRectMake(0, 0, 800, 600)
+    _window = [[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 800, 600)
                                           styleMask:windowStyleFlags
                                             backing:NSBackingStoreBuffered
                                               defer:YES];

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -94,11 +94,6 @@
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate: self];
     
     [[SUUpdater sharedUpdater] checkForUpdatesInBackground];
-    [_window makeFirstResponder:_window];
-}
-
-- (BOOL)shouldPropagateMouseDownEvent:(NSEvent *)theEvent {
-  return YES;
 }
 
 - (BOOL)shouldPropagateMouseDraggedEvent:(NSEvent*)theEvent {
@@ -139,7 +134,6 @@
     [self.statusItem.button setImage:[NSImage imageNamed:@"statusIconRead"]];
     self.statusItem.action = @selector(showAppWindow:);
 }
-
 
 - (void)showAppWindow:(id)sender {
     [NSApp activateIgnoringOtherApps:YES];

--- a/WhatsMac/Info.plist
+++ b/WhatsMac/Info.plist
@@ -34,5 +34,18 @@
 	<string>https://raw.githubusercontent.com/stonesam92/ChitChat/master/update_appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>whatsapp.net</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/WhatsMac/WAMApplication.m
+++ b/WhatsMac/WAMApplication.m
@@ -10,13 +10,6 @@
       return;
     }
 
-    if (theEvent.type == NSLeftMouseDown) {
-      if( [((AppDelegate*)self.delegate) shouldPropagateMouseDownEvent:theEvent] ) {
-        [super sendEvent:theEvent];
-      }
-      return;
-    }
-
     if (theEvent.type == NSLeftMouseDragged) {
       if( [((AppDelegate*)self.delegate) shouldPropagateMouseDraggedEvent:theEvent] ) {
         [super sendEvent:theEvent];

--- a/WhatsMac/WAMApplication.m
+++ b/WhatsMac/WAMApplication.m
@@ -3,6 +3,27 @@
 
 @implementation WAMApplication
 - (void)sendEvent:(NSEvent *)theEvent {
+    if (theEvent.type == NSLeftMouseUp) {
+      if( [((AppDelegate*)self.delegate) shouldPropagateMouseUpEvent:theEvent] ) {
+        [super sendEvent:theEvent];
+      }
+      return;
+    }
+
+    if (theEvent.type == NSLeftMouseDown) {
+      if( [((AppDelegate*)self.delegate) shouldPropagateMouseDownEvent:theEvent] ) {
+        [super sendEvent:theEvent];
+      }
+      return;
+    }
+
+    if (theEvent.type == NSLeftMouseDragged) {
+      if( [((AppDelegate*)self.delegate) shouldPropagateMouseDraggedEvent:theEvent] ) {
+        [super sendEvent:theEvent];
+      }
+      return;
+    }
+
     if (theEvent.type == NSKeyDown && (theEvent.modifierFlags & NSCommandKeyMask)) {
         NSString *chars = theEvent.charactersIgnoringModifiers;
         if (chars.length == 1) {

--- a/WhatsMac/WAMWebView.h
+++ b/WhatsMac/WAMWebView.h
@@ -1,5 +1,4 @@
 #import <WebKit/WebKit.h>
 
 @interface WAMWebView : WKWebView
-
 @end

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -36,6 +36,8 @@ div.app.three, div.app.two { top: 0px; width: 100%; height: 100%; } \
     .drawer-container-mid, .drawer-container-right, .pane-chat, .pane-intro { width: calc(100% - 388px); } \
     .three .drawer-container-mid, .three .drawer-container-right, .three .pane-chat, .three .pane-intro { width: calc(100% - 718px); } \
 }\
+.image-thumb-lores { -webkit-transform: translate3d(0,0,0); } \
+.avatar-image { -webkit-transform: translate3d(0,0,0); } \
 ';
 document.documentElement.appendChild(styleAdditions);
 

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -7,7 +7,7 @@ jQuery(document).on('click', 'input[type="file"]', function () {
 this.Notification = function (title, options) {
     n = [title, options];
     console.log(options);
-    webkit.messageHandlers.notification.postMessage([title, options.body]);
+    webkit.messageHandlers.notification.postMessage([title, options.body, options.tag]);
 };
 this.Notification.permission = 'granted';
 this.Notification.requestPermission = function(callback) {callback('granted');};
@@ -94,6 +94,12 @@ function clickOnItemWithIndex (index, scrollToItem) {
                 return false;
         }
     });
+}
+
+function openChat (rawTag) {
+    var $ = jQuery;
+    var tag = rawTag.replace('.', '=1');
+    $('div.chat[data-reactid*="' + tag + '"]').first().click();
 }
 
 function setActiveConversationAtIndex (index) {

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -5,13 +5,10 @@ jQuery(document).on('click', 'input[type="file"]', function () {
 });
 
 this.Notification = function (title, options) {
-    n = [title, options];
-    console.log(options);
     webkit.messageHandlers.notification.postMessage([title, options.body, options.tag]);
 };
 this.Notification.permission = 'granted';
 this.Notification.requestPermission = function(callback) {callback('granted');};
-
 
 var styleAdditions = document.createElement('style');
 styleAdditions.textContent = 'div.pane-list-user { opacity:0; } \


### PR DESCRIPTION
This PR adds the following features to improve ChitChat's notification delivery and user experience:

1. Open the respective chat when a notification is clicked. (https://github.com/stonesam92/ChitChat/issues/12)
2. Display only the latest notification from each chat.
3. Block notifications when ChitChat is the main window.
4. Clear all notifications with respect to remote unread status changes.

On the other hand, it also addresses the following issues:

1. Undraggable window in OS X 10.11 El Capitan (#65)
2. Sluggish scrolling performance due to the CSS blur filters.
3. Media requests being blocked due to ATS requirements. (10.11 SDK only, PR #75)
4. Cannot restore autosaved frame. (#60)

-

As a note to the undraggable window fix, I have tried overriding NSResponder methods at various spots in the view hierarchy, but all attempts were failed. So perhaps manual drag handling of this fix would be the only solution at this moment. I would definitely be glad to hear if there is a more elegant solution though. :)