### PR TITLE
[Experimental] Native Toolbar

### DIFF
--- a/WhatsMac/AppDelegate.h
+++ b/WhatsMac/AppDelegate.h
@@ -1,8 +1,11 @@
 #import <Cocoa/Cocoa.h>
+#import "WAMWebViewController.h"
+
+FOUNDATION_EXPORT NSUInteger const WAMWindowToolbarHeight;
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
 
-- (void)setActiveConversationAtIndex:(NSString*)index;
+@property(readonly) WAMWebViewController* webViewController;
 
 @end
 

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -245,6 +245,9 @@
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    if ([[self window] isMainWindow]) {
+        return;
+    }
     NSArray *messageBody = message.body;
     NSUserNotification *notification = [NSUserNotification new];
     notification.title = messageBody[0];
@@ -253,14 +256,18 @@
     [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:notification];
 }
 
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification {
+    return YES;
+}
+
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
     [self.webView evaluateJavaScript:
      [NSString stringWithFormat:@"openChat(\"%@\")", notification.identifier]
-                   completionHandler:nil];
+        completionHandler:nil];
     [center removeDeliveredNotification:notification];
 }
 
-- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)())completionHandler {
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler {
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = @"Uploading Media";
     alert.informativeText = message;

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -1,67 +1,38 @@
 #import "AppDelegate.h"
-#import "WKWebView+Private.h"
-#import "WAMWebView.h"
+#import "WAMWebViewController.h"
 
 @import WebKit;
 @import Sparkle;
+@import AppKit;
 
-@interface AppDelegate () <NSWindowDelegate, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, NSUserNotificationCenterDelegate>
+NSUInteger const WAMWindowToolbarHeight = 38;
+
+@interface AppDelegate () <NSWindowDelegate, NSUserNotificationCenterDelegate>
 @property (strong, nonatomic) NSWindow *window;
-@property (strong, nonatomic) WKWebView *webView;
+@property (strong, nonatomic) WAMWebViewController *webViewController;
+@property (strong, nonatomic) NSString *notificationCount;
 @property (strong, nonatomic) NSView* titlebarView;
 @property (strong, nonatomic) NSStatusItem *statusItem;
 @property (weak, nonatomic) NSWindow *legal;
 @property (weak, nonatomic) NSWindow *faq;
-@property (strong, nonatomic) NSString *notificationCount;
 @end
 
 @implementation AppDelegate
 
-- (WKWebViewConfiguration*)webViewConfig {
-    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    WKUserContentController *contentController = [[WKUserContentController alloc] init];
-    // inject js into webview
-    NSURL *pathToJS = [[NSBundle mainBundle] URLForResource:@"inject" withExtension:@"js"];
-    NSString *injectedJS = [NSString stringWithContentsOfURL:pathToJS encoding:NSUTF8StringEncoding error:nil];
-    WKUserScript *userScript = [[WKUserScript alloc] initWithSource:injectedJS
-                                                      injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
-                                                   forMainFrameOnly:NO];
-    NSURL *jqueryURL = [[NSBundle mainBundle] URLForResource:@"jquery" withExtension:@"js"];
-    NSString *jquery = [NSString stringWithContentsOfURL:jqueryURL encoding:NSUTF8StringEncoding error:nil];
-    WKUserScript *jqueryUserScript = [[WKUserScript alloc] initWithSource:jquery
-                                                            injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:NO];
-    [contentController addUserScript:jqueryUserScript];
-    [contentController addUserScript:userScript];
-    [contentController addScriptMessageHandler:self name:@"notification"];
-    config.userContentController = contentController;
-    
-    #if DEBUG
-    [config.preferences setValue:@YES forKey:@"developerExtrasEnabled"];
-    #else
-    WKUserScript *noRightClickJS = [[WKUserScript alloc] initWithSource:
-                                    @"document.addEventListener('contextmenu',"
-                                    "function(event) {"
-                                        "event.preventDefault();"
-                                    "});"
-                                                          injectionTime:WKUserScriptInjectionTimeAtDocumentStart
-                                                       forMainFrameOnly:NO];
-    [contentController addUserScript:noRightClickJS];
-    #endif
-    return config;
-}
-
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     NSInteger windowStyleFlags = NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask | NSFullSizeContentViewWindowMask;
     _notificationCount = @"";
+
     _window = [[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 800, 600)
                                           styleMask:windowStyleFlags
                                             backing:NSBackingStoreBuffered
                                               defer:YES];
     _window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantLight];
+    _window.backgroundColor = [NSColor colorWithRed:0.933 green:0.933 blue:0.933 alpha:1.0];
     _window.titleVisibility = NSWindowTitleHidden;
     _window.titlebarAppearsTransparent = YES;
-    _window.minSize = CGSizeMake(640, 400);
     _window.releasedWhenClosed = NO;
+    _window.minSize = CGSizeMake(600, 400);
     _window.delegate = self;
     _window.frameAutosaveName = @"main";
     _window.movableByWindowBackground = YES;
@@ -70,22 +41,18 @@
     
     _titlebarView = [_window standardWindowButton:NSWindowCloseButton].superview;
     [self updateWindowTitlebar];
-    
-    [self createStatusItem];
+  
+    _webViewController = [[WAMWebViewController alloc] initWithNibName:nil bundle:nil];
 
-    _webView = [[WAMWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)
-                                  configuration:[self webViewConfig]];
-    
-    _window.contentView = _webView;
-    _webView.UIDelegate = self;
-    _webView.navigationDelegate = self;
-    [_webView addObserver:self forKeyPath:@"title" options:NSKeyValueObservingOptionNew context:NULL];
-    
-    //Whatsapp web only works with specific user agents
-    _webView._customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12";
-    
-    NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://web.whatsapp.com"]];
-    [_webView loadRequest:urlRequest];
+    // NSWindow.contentViewController has undocumented side effects.
+    // So NSWindow.contentView is used intead.
+    _window.contentView = _webViewController.view;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(setNotificationCount:) name:WAMWebViewUpdateUnreadCountNotification object:_webViewController];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(postNativeNotification:) name:WAMWebViewNewMessageNotification object:_webViewController];
+  
+    [self createStatusItem];
+  
     [_window makeKeyAndOrderFront:self];
     
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate: self];
@@ -123,24 +90,6 @@
     [self updateWindowTitlebar];
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    NSString *title = change[NSKeyValueChangeNewKey];
-    if ([title isEqualToString:@"WhatsApp Web"]) {
-        self.notificationCount = @"";
-    } else {
-        NSRegularExpression* regex =
-        [NSRegularExpression regularExpressionWithPattern:@"\\(([0-9]+)\\) WhatsApp Web"
-                                                  options:0
-                                                    error:nil];
-        NSTextCheckingResult* match = [regex firstMatchInString:title
-                                                        options:0
-                                                          range:NSMakeRange(0, title.length)];
-        if (match) {
-            self.notificationCount = [title substringWithRange:[match rangeAtIndex:1]];
-        }
-    }
-}
-
 - (NSWindow*)legal {
     if (!_legal) {
         _legal = [self createWindow:@"legal" title:@"Legal" URL:@"https://www.whatsapp.com/legal/"];
@@ -155,7 +104,8 @@
     return _faq;
 }
 
-- (void)setNotificationCount:(NSString *)notificationCount {
+- (void)setNotificationCount:(NSNotification *)notification {
+    NSString* notificationCount = [notification.userInfo valueForKey:@"count"];
     if (![_notificationCount isEqualToString:notificationCount]) {
         [[NSApp dockTile] setBadgeLabel:notificationCount];
         
@@ -172,15 +122,25 @@
     _notificationCount = notificationCount;
 }
 
+- (void)postNativeNotification:(NSNotification *)notificaiton {
+    NSUserNotification *notification = [NSUserNotification new];
+    notification.title = [notificaiton.userInfo valueForKey:@"title"];
+    notification.subtitle = [notificaiton.userInfo valueForKey:@"subtitle"];
+    notification.identifier = [notificaiton.userInfo valueForKey:@"tag"];
+    [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:notification];
+}
+
 #pragma mark MenuBar Actions
 - (IBAction)find:(NSMenuItem*)sender {
-    [self.webView evaluateJavaScript:@"activateSearchField();"
-                   completionHandler:nil];
+    [self.webViewController find];
 }
 
 - (IBAction)newConversation:(NSMenuItem*)sender {
-    [self.webView evaluateJavaScript:@"newConversation();"
-                   completionHandler:nil];
+    [self.webViewController newConversation];
+}
+
+- (IBAction)reloadPage:(id)sender {
+  [self.webViewController reload];
 }
 
 - (IBAction)showLegal:(id)sender {
@@ -190,95 +150,20 @@
 - (IBAction)showFAQ:(id)sender {
     [self.faq makeKeyAndOrderFront:self];
 }
-
-- (IBAction)reloadPage:(id)sender {
-    NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://web.whatsapp.com"]];
-    [self.webView loadRequest:urlRequest];
-}
-
-- (void)setActiveConversationAtIndex:(NSString*)index {
-    [self.webView evaluateJavaScript:
-     [NSString stringWithFormat:@"setActiveConversationAtIndex(%@)", index]
-                   completionHandler:nil];
-}
-
-#pragma mark WebView Delegate Methods
-
-
-- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
-    NSURL *url = navigationAction.request.URL;
-    
-    if ([url.host hasSuffix:@"whatsapp.com"] || [url.scheme isEqualToString:@"file"]) {
-        decisionHandler(WKNavigationActionPolicyAllow);
-    } else if ([url.host hasSuffix:@"whatsapp.net"]) {
-        decisionHandler(WKNavigationActionPolicyCancel);
-        
-        NSAlert *downloadMediaAlert = [[NSAlert alloc] init];
-        downloadMediaAlert.messageText = @"Downloading Media";
-        downloadMediaAlert.informativeText = @"To download media, please just drag and drop it from this window into Finder.";
-        [downloadMediaAlert addButtonWithTitle:@"OK"];
-        [downloadMediaAlert runModal];
-    } else {
-        decisionHandler(WKNavigationActionPolicyCancel);
-        [[NSWorkspace sharedWorkspace] openURL:url];
-    }
-}
-
-- (void)webView:(WKWebView*)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-    NSLog(@"Failed navigation with error: %@", error);
-    [self showFailedConnectionPage];
-}
-
-- (void)webView:(WKWebView*)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-    NSLog(@"Failed navigation with error: %@", error);
-    [self showFailedConnectionPage];
-}
-
-- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
-{
-    
-    if (!navigationAction.targetFrame.isMainFrame) {
-        [[NSWorkspace sharedWorkspace] openURL:navigationAction.request.URL];
-    }
-    
-    return nil;
-}
-
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
-    if ([[self window] isMainWindow]) {
-        return;
-    }
-    NSArray *messageBody = message.body;
-    NSUserNotification *notification = [NSUserNotification new];
-    notification.title = messageBody[0];
-    notification.subtitle = messageBody[1];
-    notification.identifier = messageBody[2];
-    [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:notification];
-}
+# pragma mark NSUserNotificationCenter Delegate Methods
 
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification {
     return YES;
 }
 
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
-    [self.webView evaluateJavaScript:
-     [NSString stringWithFormat:@"openChat(\"%@\")", notification.identifier]
-        completionHandler:nil];
-    [center removeDeliveredNotification:notification];
-}
-
-- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler {
-    NSAlert *alert = [[NSAlert alloc] init];
-    alert.messageText = @"Uploading Media";
-    alert.informativeText = message;
-    [alert addButtonWithTitle:@"OK"];
-    [alert runModal];
-    completionHandler();
+  [self.webViewController openChat:notification.identifier];
+  [center removeDeliveredNotification:notification];
 }
 
 # pragma mark Utils
 - (void)updateWindowTitlebar {
-    const CGFloat kTitlebarHeight = 59;
+    const CGFloat kTitlebarHeight = WAMWindowToolbarHeight;
     const CGFloat kFullScreenButtonYOrigin = 3;
     CGRect windowFrame = _window.frame;
     BOOL fullScreen = (_window.styleMask & NSFullScreenWindowMask) == NSFullScreenWindowMask;
@@ -336,11 +221,5 @@
     window.releasedWhenClosed = YES;
     CFBridgingRetain(window);
     return window;
-}
-
-- (void)showFailedConnectionPage {
-    NSURL *failedPageURL = [[NSBundle mainBundle] URLForResource:@"noConnection" withExtension:@"html"];
-    NSURLRequest *failedPageRequest = [NSURLRequest requestWithURL:failedPageURL];
-    [self.webView loadRequest:failedPageRequest];
 }
 @end

--- a/WhatsMac/NSLabel.h
+++ b/WhatsMac/NSLabel.h
@@ -1,0 +1,16 @@
+//
+//  NSLabel.h
+//  ChitChat
+//
+//  Courtesy: Axel Guilmin
+//  http://stackoverflow.com/questions/20169298/xcode-doesnt-recognize-nslabel
+//
+
+#import <AppKit/AppKit.h>
+
+@interface NSLabel : NSTextField
+
+@property (nonatomic, assign) CGFloat fontSize;
+@property (nonatomic, strong) NSString *text;
+
+@end

--- a/WhatsMac/NSLabel.m
+++ b/WhatsMac/NSLabel.m
@@ -1,0 +1,63 @@
+//
+//  NSLabel.h
+//  ChitChat
+//
+//  Courtesy: Axel Guilmin
+//  http://stackoverflow.com/questions/20169298/xcode-doesnt-recognize-nslabel
+//
+#import "NSLabel.h"
+
+@implementation NSLabel
+
+#pragma mark INIT
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self textFieldToLabel];
+  }
+  return self;
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    [self textFieldToLabel];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
+  if (self) {
+    [self textFieldToLabel];
+  }
+  return self;
+}
+
+#pragma mark SETTER
+- (void)setFontSize:(CGFloat)fontSize {
+  super.font = [NSFont fontWithName:self.font.fontName size:fontSize];
+}
+
+- (void)setText:(NSString *)text {
+  [super setStringValue:text];
+}
+
+#pragma mark GETTER
+- (CGFloat)fontSize {
+  return super.font.pointSize;
+}
+
+- (NSString*)text {
+  return [super stringValue];
+}
+
+#pragma mark - PRIVATE
+- (void)textFieldToLabel {
+  super.bezeled = NO;
+  super.drawsBackground = NO;
+  super.editable = NO;
+  super.selectable = NO;
+}
+
+@end

--- a/WhatsMac/WAMApplication.m
+++ b/WhatsMac/WAMApplication.m
@@ -8,7 +8,7 @@
         if (chars.length == 1) {
             switch ([chars characterAtIndex:0]) {
                 case '1' ... '9':
-                    [((AppDelegate*)self.delegate) setActiveConversationAtIndex:theEvent.characters];
+                    [((AppDelegate*)self.delegate).webViewController setActiveConversationAtIndex:theEvent.characters];
                     return;
                 default:
                     break;

--- a/WhatsMac/WAMWebViewController.h
+++ b/WhatsMac/WAMWebViewController.h
@@ -1,0 +1,22 @@
+//
+//  WAMWebViewController.h
+//  ChitChat
+//
+//  Created by Anders on 28/9/2015.
+//  Copyright © 2015 Sam Stone. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import "WKWebView+Private.h"
+
+FOUNDATION_EXPORT NSString *const WAMWebViewUpdateUnreadCountNotification;
+FOUNDATION_EXPORT NSString *const WAMWebViewNewMessageNotification;
+
+@interface WAMWebViewController : NSViewController
+@property (readonly) WKWebView *webView;
+- (void)find;
+- (void)newConversation;
+- (void)openChat:(NSString*) identifier;
+- (void)setActiveConversationAtIndex:(NSString*)index;
+- (void)reload;
+@end

--- a/WhatsMac/WAMWebViewController.m
+++ b/WhatsMac/WAMWebViewController.m
@@ -1,0 +1,365 @@
+//
+//  WAMWebViewController.m
+//  ChitChat
+//
+//  Created by Anders on 28/9/2015.
+//  Copyright © 2015 Sam Stone. All rights reserved.
+//
+
+#import <AppKit/AppKit.h>
+#import "WAMWebViewController.h"
+#import "WAMApplication.h"
+#import "WKWebView+Private.h"
+#import "WAMWebView.h"
+#import "AppDelegate.h"
+#import "NSLabel.h"
+
+NSString *const WAMWebViewUpdateUnreadCountNotification = @"WAMWebViewUpdateUnreadCountNotification";
+NSString *const WAMWebViewNewMessageNotification = @"WAMWebViewNewMessageNotification";
+
+@interface WAMWebViewController () <WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>
+@property (strong, nonatomic) WKWebView* webView;
+@property (strong, nonatomic) NSButton* toggleForNewConversation;
+@property (strong, nonatomic) NSLabel* conversationTitle;
+@property (strong, nonatomic) NSLabel* conversationSubtitle;
+@property (strong, nonatomic) NSImage* conversationIcon;
+@property (strong, nonatomic) NSView* conversationViewBorder;
+@property (strong, nonatomic) NSView* webViewBorder;
+
+@end
+
+@implementation WAMWebViewController
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  return self;
+}
+
+#pragma mark View Configuration
+
+- (void)loadView {
+  self.view = [[NSView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  [self.view setAutoresizingMask: NSViewWidthSizable |  NSViewHeightSizable];
+  [self.view setWantsLayer:YES];
+  
+  _webView = [[WAMWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)
+                                 configuration:[self webViewConfig]];
+  _webView.translatesAutoresizingMaskIntoConstraints = NO;
+  [_webView setWantsLayer:YES];
+  [self.view addSubview:_webView];
+  
+  /// Border
+  _webViewBorder = [NSView new];
+  _webViewBorder.translatesAutoresizingMaskIntoConstraints = NO;
+  [_webViewBorder setWantsLayer:YES];
+  [_webViewBorder.layer setBackgroundColor:[[NSColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:0.08] CGColor]];
+  [self.view addSubview:_webViewBorder];
+  
+  /// New Conversation Toggle
+  
+  _toggleForNewConversation = [NSButton new];
+  [_toggleForNewConversation setButtonType:NSToggleButton];
+  [_toggleForNewConversation setImage:[NSImage imageNamed:NSImageNameAddTemplate]];
+  [_toggleForNewConversation setAlternateImage:[NSImage imageNamed:NSImageNameGoLeftTemplate]];
+  _toggleForNewConversation.bezelStyle = NSTexturedSquareBezelStyle;
+  _toggleForNewConversation.translatesAutoresizingMaskIntoConstraints = NO;
+  [_toggleForNewConversation setTarget:self];
+  [_toggleForNewConversation setAction:@selector(newConversation)];
+  [_toggleForNewConversation setHidden:YES];
+  [self.view addSubview:_toggleForNewConversation];
+  
+  /// Conversation Labels
+  NSView* backgroundView = [NSView new];
+  backgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.view addSubview:backgroundView];
+
+  _conversationTitle = [NSLabel new];
+  [_conversationTitle setText:@"test"];
+  [_conversationTitle setFontSize:14.0];
+  [_conversationTitle setHidden:YES];
+  _conversationTitle.lineBreakMode = NSLineBreakByTruncatingTail;
+  [_conversationTitle setContentCompressionResistancePriority:NSLayoutPriorityFittingSizeCompression forOrientation:NSLayoutConstraintOrientationHorizontal];
+  
+  _conversationSubtitle = [NSLabel new];
+  [_conversationSubtitle setText:@"test subtitle."];
+  [_conversationSubtitle setFontSize:9.0];
+  [_conversationSubtitle setHidden:YES];
+  _conversationSubtitle.lineBreakMode = NSLineBreakByTruncatingTail;
+    [_conversationSubtitle setContentCompressionResistancePriority:NSLayoutPriorityFittingSizeCompression forOrientation:NSLayoutConstraintOrientationHorizontal];
+
+
+  
+  _conversationTitle.translatesAutoresizingMaskIntoConstraints = NO;
+  _conversationSubtitle.translatesAutoresizingMaskIntoConstraints = NO;
+  [backgroundView addSubview:_conversationTitle];
+  [backgroundView addSubview:_conversationSubtitle];
+  
+  _conversationViewBorder = [NSView new];
+  _conversationViewBorder.translatesAutoresizingMaskIntoConstraints = NO;
+  [_conversationViewBorder setWantsLayer:YES];
+  [_conversationViewBorder.layer setBackgroundColor:[[NSColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:0.08] CGColor]];
+  [_conversationViewBorder setHidden:YES];
+  [backgroundView addSubview:_conversationViewBorder];
+  
+  /// Constraints
+  NSArray* hConstraints;
+  NSArray* vConstraints;
+  NSDictionary<NSString *, id>* dict;
+  
+  /// - Border & WebView
+  dict = [NSDictionary dictionaryWithObjects:@[_webView, _webViewBorder] forKeys:@[@"webview", @"border"]];
+  hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[border]|" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  [self.view addConstraints:hConstraints];
+
+  hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[webview]|" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  vConstraints = [NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|-%lu-[border(1)][webview]|", WAMWindowToolbarHeight] options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  [self.view addConstraints:hConstraints];
+  [self.view addConstraints:vConstraints];
+  
+  /// - New Conversation Toggle
+  dict = [NSDictionary dictionaryWithObjects:@[_toggleForNewConversation] forKeys:@[@"button"]];
+  hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-80-[button(42)]" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  vConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|-7-[button(24)]" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  [self.view addConstraints:hConstraints];
+  [self.view addConstraints:vConstraints];
+  
+  /// - Conversation Details Container
+  dict = [NSDictionary dictionaryWithObjects:@[backgroundView] forKeys:@[@"background"]];
+  vConstraints = [NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|[background(%lu)]", WAMWindowToolbarHeight] options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  NSLayoutConstraint* hConstraint3a = [NSLayoutConstraint constraintWithItem:backgroundView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeWidth multiplier: 0.62 constant:0];
+  NSLayoutConstraint* hConstraint3b = [NSLayoutConstraint constraintWithItem:backgroundView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeTrailing multiplier:1 constant:0];
+
+  [self.view addConstraints:vConstraints];
+  [self.view addConstraint:hConstraint3a];
+  [self.view addConstraint:hConstraint3b];
+  
+  /// - Conversation Details Border
+  dict = [NSDictionary dictionaryWithObjects:@[_conversationViewBorder] forKeys:@[@"border"]];
+  hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[border(1)]" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  vConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[border]|" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  [self.view addConstraints:hConstraints];
+  [self.view addConstraints:vConstraints];
+  
+  /// - Labels for Conversation Details
+  dict = [NSDictionary dictionaryWithObjects:@[_conversationTitle, _conversationSubtitle] forKeys:@[@"title", @"subtitle"]];
+  hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-15-[title]-15-|" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  vConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|-2-[title]-(0)-[subtitle]-2-|" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  [self.view addConstraints:hConstraints];
+  [self.view addConstraints:vConstraints];
+  
+  hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-15-[subtitle]-15-|" options:NSLayoutFormatAlignAllLeft metrics:nil views:dict];
+  [self.view addConstraints:hConstraints];
+
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+  
+  _webView.UIDelegate = self;
+  _webView.navigationDelegate = self;
+  [_webView addObserver:self forKeyPath:@"title" options:NSKeyValueObservingOptionNew context:NULL];
+
+  //Whatsapp web only works with specific user agents
+  _webView._customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12";
+  
+  NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://web.whatsapp.com"]];
+  [_webView loadRequest:urlRequest];
+}
+
+#pragma mark External Actions
+- (void)find {
+  [self.webView evaluateJavaScript:@"activateSearchField();"
+                                   completionHandler:nil];
+}
+
+- (void)newConversation {
+  [self.webView evaluateJavaScript:@"newConversation();"
+                                   completionHandler:nil];
+}
+
+- (void)openChat:(NSString*)identifier {
+  [self.webView evaluateJavaScript:
+   [NSString stringWithFormat:@"openChat(\"%@\")", identifier]
+                 completionHandler:nil];
+}
+
+- (void)reload {
+  NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://web.whatsapp.com"]];
+  [self.webView loadRequest:urlRequest];
+}
+
+- (void)setActiveConversationAtIndex:(NSString*)index {
+  [self.webView evaluateJavaScript:
+   [NSString stringWithFormat:@"setActiveConversationAtIndex(%@)", index]
+                 completionHandler:nil];
+}
+
+#pragma mark Internal Actions
+- (void)webAppDidLoad {
+  [_conversationViewBorder setHidden:NO];
+  [_toggleForNewConversation setHidden:NO];
+}
+
+- (void)updateConversationDetailsWithTitle:(NSString*) title subTitle:(NSString*) subtitle {
+  if( _conversationTitle.hidden ) {
+    [_conversationTitle setHidden:NO];
+    [_conversationSubtitle setHidden:NO];
+  }
+  
+  _conversationTitle.text = title;
+  _conversationSubtitle.text = subtitle;
+}
+
+- (void)updateConversationSubtitle:(NSString*) subtitle {
+  _conversationSubtitle.text = subtitle;
+}
+
+#pragma mark Internal Utils
+
+- (void)showFailedConnectionPage {
+  NSURL *failedPageURL = [[NSBundle mainBundle] URLForResource:@"noConnection" withExtension:@"html"];
+  NSURLRequest *failedPageRequest = [NSURLRequest requestWithURL:failedPageURL];
+  [self.webView loadRequest:failedPageRequest];
+}
+
+- (WKWebViewConfiguration*)webViewConfig {
+  WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+  WKUserContentController *contentController = [[WKUserContentController alloc] init];
+  // inject js into webview
+  NSURL *pathToJS = [[NSBundle mainBundle] URLForResource:@"inject" withExtension:@"js"];
+  NSString *injectedJS = [NSString stringWithContentsOfURL:pathToJS encoding:NSUTF8StringEncoding error:nil];
+  WKUserScript *userScript = [[WKUserScript alloc] initWithSource:injectedJS
+                                                    injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
+                                                 forMainFrameOnly:NO];
+  NSURL *jqueryURL = [[NSBundle mainBundle] URLForResource:@"jquery" withExtension:@"js"];
+  NSString *jquery = [NSString stringWithContentsOfURL:jqueryURL encoding:NSUTF8StringEncoding error:nil];
+  WKUserScript *jqueryUserScript = [[WKUserScript alloc] initWithSource:jquery
+                                                          injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:NO];
+  [contentController addUserScript:jqueryUserScript];
+  [contentController addUserScript:userScript];
+  [contentController addScriptMessageHandler:self name:@"notification"];
+  config.userContentController = contentController;
+  
+#if DEBUG
+  [config.preferences setValue:@YES forKey:@"developerExtrasEnabled"];
+#else
+  WKUserScript *noRightClickJS = [[WKUserScript alloc] initWithSource:
+                                  @"document.addEventListener('contextmenu',"
+                                  "function(event) {"
+                                  "event.preventDefault();"
+                                  "});"
+                                                        injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+                                                     forMainFrameOnly:NO];
+  [contentController addUserScript:noRightClickJS];
+#endif
+  return config;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+  NSString *title = change[NSKeyValueChangeNewKey];
+  if ([title isEqualToString:@"WhatsApp Web"]) {
+    NSDictionary* userInfo = [NSDictionary dictionaryWithObject:@"" forKey:@"count"];
+    [[NSNotificationCenter defaultCenter] postNotificationName:WAMWebViewUpdateUnreadCountNotification object:self userInfo:userInfo];
+  } else {
+    NSRegularExpression* regex =
+    [NSRegularExpression regularExpressionWithPattern:@"\\(([0-9]+)\\) WhatsApp Web"
+                                              options:0
+                                                error:nil];
+    NSTextCheckingResult* match = [regex firstMatchInString:title
+                                                    options:0
+                                                      range:NSMakeRange(0, title.length)];
+    if (match) {
+      NSString* count = [title substringWithRange:[match rangeAtIndex:1]];
+      NSDictionary* userInfo = [NSDictionary dictionaryWithObject:count forKey:@"count"];
+      [[NSNotificationCenter defaultCenter] postNotificationName:WAMWebViewUpdateUnreadCountNotification object:self userInfo:userInfo];
+    }
+  }
+}
+
+#pragma mark WKNavigationDelegate methods
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+  [_toggleForNewConversation setEnabled:YES];
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+  NSURL *url = navigationAction.request.URL;
+  
+  if ([url.host hasSuffix:@"whatsapp.com"] || [url.scheme isEqualToString:@"file"]) {
+    decisionHandler(WKNavigationActionPolicyAllow);
+  } else if ([url.host hasSuffix:@"whatsapp.net"]) {
+    decisionHandler(WKNavigationActionPolicyCancel);
+    
+    NSAlert *downloadMediaAlert = [[NSAlert alloc] init];
+    downloadMediaAlert.messageText = @"Downloading Media";
+    downloadMediaAlert.informativeText = @"To download media, please just drag and drop it from this window into Finder.";
+    [downloadMediaAlert addButtonWithTitle:@"OK"];
+    [downloadMediaAlert runModal];
+  } else {
+    decisionHandler(WKNavigationActionPolicyCancel);
+    [[NSWorkspace sharedWorkspace] openURL:url];
+  }
+}
+
+- (void)webView:(WKWebView*)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+  NSLog(@"Failed navigation with error: %@", error);
+  [self showFailedConnectionPage];
+}
+
+- (void)webView:(WKWebView*)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+  NSLog(@"Failed navigation with error: %@", error);
+  [self showFailedConnectionPage];
+}
+
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+  
+  if (!navigationAction.targetFrame.isMainFrame) {
+    [[NSWorkspace sharedWorkspace] openURL:navigationAction.request.URL];
+  }
+  
+  return nil;
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler {
+  NSAlert *alert = [[NSAlert alloc] init];
+  alert.messageText = @"Uploading Media";
+  alert.informativeText = message;
+  [alert addButtonWithTitle:@"OK"];
+  [alert runModal];
+  completionHandler();
+}
+
+#pragma mark WKScriptMessageHandler delegate methods
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+  NSArray *messageBody = message.body;
+  NSString *messageType = messageBody[0];
+  
+  if( [messageType isEqualToString:@"WAMNotification"] ) {
+    if ([[[self view] window] isMainWindow]) {
+      return;
+    }
+
+    NSDictionary* userInfo = [NSDictionary dictionaryWithObjects:@[messageBody[1], messageBody[2], messageBody[3]] forKeys:@[@"title", @"subtitle", @"tag"]];
+    [[NSNotificationCenter defaultCenter] postNotificationName:WAMWebViewNewMessageNotification object:self userInfo:userInfo];
+    return;
+  }
+  
+  if( [messageType isEqualToString:@"WAMConversationStatus"] ) {
+    [self updateConversationSubtitle:messageBody[1]];
+    return;
+  }
+  
+  if( [messageType isEqualToString:@"WAMConversationDetails"] ) {
+    [self updateConversationDetailsWithTitle:messageBody[1] subTitle:messageBody[2]];
+    return;
+  }
+
+  if( [messageType isEqualToString:@"WAMWebAppLoaded"] ) {
+    [self webAppDidLoad];
+    return;
+  }
+}
+
+@end

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -7,7 +7,7 @@ jQuery(document).on('click', 'input[type="file"]', function () {
 this.Notification = function (title, options) {
     n = [title, options];
     console.log(options);
-    webkit.messageHandlers.notification.postMessage([title, options.body]);
+    webkit.messageHandlers.notification.postMessage([title, options.body, options.tag]);
 };
 this.Notification.permission = 'granted';
 this.Notification.requestPermission = function(callback) {callback('granted');};
@@ -94,6 +94,12 @@ function clickOnItemWithIndex (index, scrollToItem) {
                 return false;
         }
     });
+}
+
+function openChat (rawTag) {
+    var $ = jQuery;
+    var tag = rawTag.replace('.', '=1');
+    $('div.chat[data-reactid*="' + tag + '"]').first().click();
 }
 
 function setActiveConversationAtIndex (index) {

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -5,13 +5,10 @@ jQuery(document).on('click', 'input[type="file"]', function () {
 });
 
 this.Notification = function (title, options) {
-    n = [title, options];
-    console.log(options);
     webkit.messageHandlers.notification.postMessage([title, options.body, options.tag]);
 };
 this.Notification.permission = 'granted';
 this.Notification.requestPermission = function(callback) {callback('granted');};
-
 
 var styleAdditions = document.createElement('style');
 styleAdditions.textContent = 'div.pane-list-user { opacity:0; } \

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -11,7 +11,9 @@ this.Notification.permission = 'granted';
 this.Notification.requestPermission = function(callback) {callback('granted');};
 
 var styleAdditions = document.createElement('style');
-styleAdditions.textContent = 'div.pane-list-user { opacity:0; } \
+styleAdditions.textContent = 'header { display: none !important; } \
+.image-thumb-lores { -webkit-transform: translate3d(0,0,0); } \
+div.pane-list-user { opacity:0; } \
 div.pane-list-user > div.avatar { width: 0px; height: 0px; } \
 div.app-wrapper::before { opacity: 0; } \
 div.drawer-title { left:60px; bottom:17px; } \

--- a/WhatsMac/inject.js
+++ b/WhatsMac/inject.js
@@ -5,7 +5,7 @@ jQuery(document).on('click', 'input[type="file"]', function () {
 });
 
 this.Notification = function (title, options) {
-    webkit.messageHandlers.notification.postMessage([title, options.body, options.tag]);
+    webkit.messageHandlers.notification.postMessage(["WAMNotification", title, options.body, options.tag]);
 };
 this.Notification.permission = 'granted';
 this.Notification.requestPermission = function(callback) {callback('granted');};
@@ -13,6 +13,7 @@ this.Notification.requestPermission = function(callback) {callback('granted');};
 var styleAdditions = document.createElement('style');
 styleAdditions.textContent = 'header { display: none !important; } \
 .image-thumb-lores { -webkit-transform: translate3d(0,0,0); } \
+.avatar-image { -webkit-transform: translate3d(0,0,0); } \
 div.pane-list-user { opacity:0; } \
 div.pane-list-user > div.avatar { width: 0px; height: 0px; } \
 div.app-wrapper::before { opacity: 0; } \
@@ -46,7 +47,19 @@ function activateSearchField () {
 }
 
 function newConversation () {
-    document.querySelector('button.icon-chat').click();
+  var backButton = document.querySelector('button.btn-close-drawer');
+  if( backButton !== null ) {
+    backButton.click();
+    return
+  }
+  
+  var newButton = document.querySelector('button.icon-chat');
+  if( newButton == null ) {
+    // Page is not yet loaded.
+    return
+  }
+  
+    newButton.click();
     document.querySelector('input.input-search').focus();
     
     var header = document.querySelector('div.drawer-title');
@@ -123,8 +136,107 @@ function setActiveConversationAtIndex (index) {
     conversationList.scrollTop = 0;
 }
 
+var injectChangeObserver = new MutationObserver(function(records) {
+    var $ = jQuery;
+      for(var i = 0; i < records.length; i++) {
+          if( records[i].addedNodes.length > 0 ) {
+              for(var j = 0; j < records[i].addedNodes.length; j++) {
+                  if( $(records[i].addedNodes[j]).hasClass('app') ) {
+                    conversationChangeObserver.observe(records[i].addedNodes[j], {
+                      "childList": true
+                    })
+                    webkit.messageHandlers.notification.postMessage(["WAMWebAppLoaded"]);
+                    this.disconnect();
+                    break
+                  }
+              }
+          }
+      }
+});
+
+var conversationChangeObserver = new MutationObserver(function(records) {
+  var $ = jQuery;
+  for(var i = 0; i < records.length; i++) {
+      if( records[i].addedNodes.length > 0 ) {
+          for(var j = 0; j < records[i].addedNodes.length; j++) {
+              if( $(records[i].addedNodes[j]).hasClass('pane-chat') ) {
+                updateConversationDetails(records[i].addedNodes[j]);
+                break
+              }
+          }
+      }
+  }
+});
+
+var chatStatusObserver = new MutationObserver(function(records) {
+  var $ = jQuery;
+  var latest = null;
+  for(var i = 0; i < records.length; i++) {
+      if( records[i].addedNodes.length > 0 ) {
+          for(var j = 0; j < records[i].addedNodes.length; j++) {
+              if( $(records[i].addedNodes[j]).hasClass('chat-status') ) {
+                lastest = records[i].addedNodes[j];
+              }
+          }
+      }
+  }
+  
+  if( latest !== null ) updateConversationStatus(lastest);
+});
+
+var chatStatusObserver2 = new MutationObserver(function(records) {
+  var $ = jQuery;
+  for(var i = 0; i < records.length; i++) {
+      if( records[i].attributeName == "title" ) {
+        updateConversationStatusWithText(records[i].target.title)
+      }
+  }
+});
+
+function updateConversationDetails(_panel) {
+  var $ = jQuery;
+  var panel = $(_panel);
+  
+  var title = panel.find('.chat-title > span.emojitext').first().attr("title");
+  var statusSpan = panel.find('.chat-status > span.emojitext')[0];
+  var statusText = statusSpan.title || "";
+  
+  statusText = statusText.indexOf("click here for") == 0 ? "" : statusText
+
+  chatStatusObserver2.disconnect();
+  chatStatusObserver2.observe(statusSpan, {
+    "attributes": true
+  })
+
+  chatStatusObserver.disconnect();
+  chatStatusObserver.observe(jQuery(_panel).find('div.chat-body')[0], {
+    "childList": true
+  })
+  webkit.messageHandlers.notification.postMessage(["WAMConversationDetails", title, statusText]);
+}
+
+function updateConversationStatus(_status) {
+  chatStatusObserver2.disconnect();
+  chatStatusObserver2.observe(status, {
+    "attributes": true
+  })
+
+  var status = jQuery(_status).find('span.emojitext').first().attr("title");
+
+  webkit.messageHandlers.notification.postMessage(["WAMConversationStatus", status]);
+}
+
+function updateConversationStatusWithText(text) {
+  webkit.messageHandlers.notification.postMessage(["WAMConversationStatus", text]);
+}
+
 jQuery(function () {
     (function ($) {
+     
+     injectChangeObserver.observe($('.app-wrapper')[0], {
+         "childList": true
+    })
+
         $(document).keydown(function (event) {
             if (!CHAT_ITEM_HEIGHT) {
                 CHAT_ITEM_HEIGHT = parseInt($($('.infinite-list-viewport .infinite-list-item')[0]).height());


### PR DESCRIPTION
As there is seemingly no easy workaround to the undraggable window issue (https://github.com/stonesam92/ChitChat/issues/65), here comes an experimental approach to tackle the issue. The idea is to use native controls like NSButton NSTextFields to replicate the web app's top toolbar (new conversation, ), and they would be updated using information provided by the DOM MutationObserver interface.

### Changes
1. A native toolbar using NSButton and NSTextField.
2. Code refactoring: WebView related logic is now in the new WAMWebViewController class.
3. Enforced hardware acceleration on blur-filtered images to improve scrolling performance.
4. Includes https://github.com/stonesam92/ChitChat/pull/73

### Not yet implemented
1. Several menu controls.
2. Avatar.


P.S. I am thinking if using NSTrackingArea would be a simpler approach... hmm.