### PR TITLE
[Fix] App Transport Security blocks media loading (OSX 10.11 SDK)

### DIFF
--- a/WhatsMac/Info.plist
+++ b/WhatsMac/Info.plist
@@ -34,5 +34,18 @@
 	<string>https://raw.githubusercontent.com/stonesam92/ChitChat/master/update_appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>whatsapp.net</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
App Transport Security (ATS) is enforced on builds targeting 10.11 SDK. Unfortunately, per the diagnostic, the media servers do not support Perfect Forward Secrecy at this moment, and consequently all media requests to `*.whatsapp.net` are blocked. Hence, this patch adds `*.whatsapp.net` as an exception to ATS's PFS requirement.