### PR TITLE
Double Click to Minimise/Zoom & Fixes for Missing Traffic Light and Dark Menu Bar

### DIFF
--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -10,7 +10,6 @@
 @interface AppDelegate () <NSWindowDelegate, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, NSUserNotificationCenterDelegate>
 @property (strong, nonatomic) NSWindow *window;
 @property (strong, nonatomic) WKWebView *webView;
-@property (strong, nonatomic) NSView* titlebarView;
 @property (strong, nonatomic) NSStatusItem *statusItem;
 @property (weak, nonatomic) NSWindow *legal;
 @property (weak, nonatomic) NSWindow *faq;
@@ -71,8 +70,7 @@
     _window.frameAutosaveName = @"main";
     _window.collectionBehavior = NSWindowCollectionBehaviorFullScreenPrimary;
   
-    _titlebarView = [_window standardWindowButton:NSWindowCloseButton].superview;
-    [self updateWindowTitlebar];
+    [self updateTitlebarOfWindow:_window forFullScreen:NO];
     
     [self createStatusItem];
 
@@ -153,8 +151,16 @@
     return YES;
 }
 
+- (void)windowWillEnterFullScreen:(NSNotification *)notification {
+  [self updateTitlebarOfWindow:_window forFullScreen:YES];
+}
+
+- (void)windowDidExitFullScreen:(NSNotification *)notification {
+  [self updateTitlebarOfWindow:_window forFullScreen:NO];
+}
+
 - (void)windowDidResize:(NSNotification *)notification {
-    [self updateWindowTitlebar];
+    [self updateTitlebarOfWindow:_window forFullScreen:NO];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
@@ -311,14 +317,13 @@
 }
 
 # pragma mark Utils
-- (void)updateWindowTitlebar {
+- (void)updateTitlebarOfWindow:(NSWindow*)window forFullScreen:(BOOL)fullScreen {
     const CGFloat kTitlebarHeight = 59;
     const CGFloat kFullScreenButtonYOrigin = 3;
-    CGRect windowFrame = _window.frame;
-    BOOL fullScreen = (_window.styleMask & NSFullScreenWindowMask) == NSFullScreenWindowMask;
-    
+    CGRect windowFrame = window.frame;
+  
     // Set size of titlebar container
-    NSView *titlebarContainerView = _titlebarView.superview;
+  NSView *titlebarContainerView = [window standardWindowButton:NSWindowCloseButton].superview.superview;
     CGRect titlebarContainerFrame = titlebarContainerView.frame;
     titlebarContainerFrame.origin.y = windowFrame.size.height - kTitlebarHeight;
     titlebarContainerFrame.size.height = kTitlebarHeight;
@@ -326,9 +331,9 @@
     
     // Set position of window buttons
     CGFloat buttonX = 12; // initial LHS margin, matching Safari 8.0 on OS X 10.10.
-    NSView *closeButton = [self.window standardWindowButton:NSWindowCloseButton];
-    NSView *minimizeButton = [self.window standardWindowButton:NSWindowMiniaturizeButton];
-    NSView *zoomButton = [self.window standardWindowButton:NSWindowZoomButton];
+    NSView *closeButton = [window standardWindowButton:NSWindowCloseButton];
+    NSView *minimizeButton = [window standardWindowButton:NSWindowMiniaturizeButton];
+    NSView *zoomButton = [window standardWindowButton:NSWindowZoomButton];
     for (NSView *buttonView in @[closeButton, minimizeButton, zoomButton]){
         CGRect buttonFrame = buttonView.frame;
         

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -158,9 +158,12 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
 }
 
 - (void)createStatusItem {
+    NSImage* image = [NSImage imageNamed:@"statusIconRead"];
+    [image setTemplate:YES];
+
     self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
-    [self.statusItem.button setImage:[NSImage imageNamed:@"statusIconRead"]];
-    self.statusItem.action = @selector(showAppWindow:);
+    [self.statusItem.button setImage:image];
+    self.statusItem.button.action = @selector(showAppWindow:);
 }
 
 - (IBAction)toggleStatusItem:(id)sender {
@@ -244,10 +247,13 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
         NSInteger badgeCount = notificationCount.integerValue;
         
         if (badgeCount) {
-            [self.statusItem.button setImage:[NSImage imageNamed:@"statusIconUnread"]];
-        }
-        else {
-            [self.statusItem.button setImage:[NSImage imageNamed:@"statusIconRead"]];
+            NSImage* image = [NSImage imageNamed:@"statusIconUnread"];
+            [self.statusItem.button setImage:image];
+        } else {
+            NSImage* image = [NSImage imageNamed:@"statusIconRead"];
+            [image setTemplate:YES];
+
+            [self.statusItem.button setImage:image];
             [[NSUserNotificationCenter defaultUserNotificationCenter] removeAllDeliveredNotifications];
         }
     }

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -78,7 +78,7 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
   
     [self updateTitlebarOfWindow:_window fullScreen:NO];
     
-     [self doubleClickPreferenceDidChange:nil];
+    [self doubleClickPreferenceDidChange:nil];
     [[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(doubleClickPreferenceDidChange:) name:_AppleActionOnDoubleClickNotification object:nil];
   
     NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -9,6 +9,7 @@
 
 NSString *const _AppleActionOnDoubleClickKey = @"AppleActionOnDoubleClick";
 NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppearancePreferenceChanged";
+NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
 
 @interface AppDelegate () <NSWindowDelegate, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, NSUserNotificationCenterDelegate>
 @property (strong, nonatomic) NSWindow *window;
@@ -75,12 +76,18 @@ NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppear
     _window.frameAutosaveName = @"main";
     _window.collectionBehavior = NSWindowCollectionBehaviorFullScreenPrimary;
   
-    [self updateTitlebarOfWindow:_window forFullScreen:NO];
+    [self updateTitlebarOfWindow:_window fullScreen:NO];
     
-    [self createStatusItem];
-  
-    [self doubleClickPreferenceDidChange:nil];
+     [self doubleClickPreferenceDidChange:nil];
     [[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(doubleClickPreferenceDidChange:) name:_AppleActionOnDoubleClickNotification object:nil];
+  
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    [defaults registerDefaults:[NSDictionary dictionaryWithObject:[NSNumber numberWithBool:NO] forKey:WAMShouldHideStatusItem]];
+    if( ![defaults boolForKey:WAMShouldHideStatusItem] ) {
+      [self createStatusItem];
+    } else {
+      [self.statusItemToggle setTitle:@"Show Status Icon"];
+    }
 
     _webView = [[WAMWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)
                                   configuration:[self webViewConfig]];
@@ -187,15 +194,15 @@ NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppear
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification *)notification {
-    [self updateTitlebarOfWindow:_window forFullScreen:YES];
+    [self updateTitlebarOfWindow:_window fullScreen:YES];
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification {
-    [self updateTitlebarOfWindow:_window forFullScreen:NO];
+    [self updateTitlebarOfWindow:_window fullScreen:NO];
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
-    [self updateTitlebarOfWindow:_window forFullScreen:NO];
+    [self updateTitlebarOfWindow:_window fullScreen:NO];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
@@ -352,7 +359,7 @@ NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppear
 }
 
 # pragma mark Utils
-- (void)updateTitlebarOfWindow:(NSWindow*)window forFullScreen:(BOOL)fullScreen {
+- (void)updateTitlebarOfWindow:(NSWindow*)window fullScreen:(BOOL)fullScreen {
     const CGFloat kTitlebarHeight = 59;
     const CGFloat kFullScreenButtonYOrigin = 3;
     CGRect windowFrame = window.frame;

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -102,47 +102,47 @@ NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppear
 }
 
 - (BOOL)shouldPropagateMouseDraggedEvent:(NSEvent*)theEvent {
-  if( ![theEvent.window isEqual:_window] ) {
-    return YES;
-  }
-  
-  if( !_isDragging ) {
-    _isDragging = YES;
-    _initialDragPosition = theEvent.locationInWindow;
-  }
-  
-  if( _initialDragPosition.y < (_window.frame.size.height - 59) ) {
-    return YES;
-  }
-  
-  NSPoint mouseLocation = [NSEvent mouseLocation];
-  NSRect newFrame = NSRectFromCGRect(_window.frame);
-  newFrame.origin.x = mouseLocation.x - _initialDragPosition.x;
-  newFrame.origin.y = mouseLocation.y - _initialDragPosition.y;
+    if( ![theEvent.window isEqual:_window] ) {
+      return YES;
+    }
+    
+    if( !_isDragging ) {
+      _isDragging = YES;
+      _initialDragPosition = theEvent.locationInWindow;
+    }
+    
+    if( _initialDragPosition.y < (_window.frame.size.height - 59) ) {
+      return YES;
+    }
+    
+    NSPoint mouseLocation = [NSEvent mouseLocation];
+    NSRect newFrame = NSRectFromCGRect(_window.frame);
+    newFrame.origin.x = mouseLocation.x - _initialDragPosition.x;
+    newFrame.origin.y = mouseLocation.y - _initialDragPosition.y;
 
-  [_window.animator setFrame:newFrame display:YES animate:NO];
-  
-  return NO;
+    [_window.animator setFrame:newFrame display:YES animate:NO];
+    
+    return NO;
 }
 
 - (BOOL)shouldPropagateMouseUpEvent:(NSEvent *)theEvent {
-  if( _isDragging ) {
-    _isDragging = NO;
-    return NO;
-  }
-  
-  if( theEvent.locationInWindow.y >= (_window.frame.size.height - 59) ) {
-    if( theEvent.clickCount == 2 ) {
-      if( _doubleClickShouldMinimize ) {
-        [_window miniaturize:self];
-      } else {
-        [_window zoom:self];
-      }
+    if( _isDragging ) {
+      _isDragging = NO;
       return NO;
     }
-  }
-  
-  return YES;
+    
+    if( theEvent.locationInWindow.y >= (_window.frame.size.height - 59) ) {
+      if( theEvent.clickCount == 2 ) {
+        if( _doubleClickShouldMinimize ) {
+          [_window miniaturize:self];
+        } else {
+          [_window zoom:self];
+        }
+        return NO;
+      }
+    }
+    
+    return YES;
 }
 
 - (void)doubleClickPreferenceDidChange:(NSNotification*)notification {
@@ -174,11 +174,11 @@ NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppear
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification *)notification {
-  [self updateTitlebarOfWindow:_window forFullScreen:YES];
+    [self updateTitlebarOfWindow:_window forFullScreen:YES];
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification {
-  [self updateTitlebarOfWindow:_window forFullScreen:NO];
+    [self updateTitlebarOfWindow:_window forFullScreen:NO];
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
@@ -345,7 +345,7 @@ NSString *const _AppleActionOnDoubleClickNotification = @"AppleNoRedisplayAppear
     CGRect windowFrame = window.frame;
   
     // Set size of titlebar container
-  NSView *titlebarContainerView = [window standardWindowButton:NSWindowCloseButton].superview.superview;
+    NSView *titlebarContainerView = [window standardWindowButton:NSWindowCloseButton].superview.superview;
     CGRect titlebarContainerFrame = titlebarContainerView.frame;
     titlebarContainerFrame.origin.y = windowFrame.size.height - kTitlebarHeight;
     titlebarContainerFrame.size.height = kTitlebarHeight;

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -83,7 +83,7 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
   
     NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
     [defaults registerDefaults:[NSDictionary dictionaryWithObject:[NSNumber numberWithBool:NO] forKey:WAMShouldHideStatusItem]];
-    if( ![defaults boolForKey:WAMShouldHideStatusItem] ) {
+    if (![defaults boolForKey:WAMShouldHideStatusItem]) {
       [self createStatusItem];
     } else {
       [self.statusItemToggle setTitle:@"Show Status Icon"];
@@ -110,16 +110,16 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
 }
 
 - (BOOL)shouldPropagateMouseDraggedEvent:(NSEvent*)theEvent {
-    if( ![theEvent.window isEqual:_window] ) {
+    if (![theEvent.window isEqual:_window]) {
       return YES;
     }
     
-    if( !_isDragging ) {
+    if (!_isDragging) {
       _isDragging = YES;
       _initialDragPosition = theEvent.locationInWindow;
     }
     
-    if( _initialDragPosition.y < (_window.frame.size.height - 59) ) {
+    if (_initialDragPosition.y < (_window.frame.size.height - 59)) {
       return YES;
     }
     
@@ -134,14 +134,14 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
 }
 
 - (BOOL)shouldPropagateMouseUpEvent:(NSEvent *)theEvent {
-    if( _isDragging ) {
+    if (_isDragging) {
       _isDragging = NO;
       return NO;
     }
     
-    if( theEvent.locationInWindow.y >= (_window.frame.size.height - 59) ) {
-      if( theEvent.clickCount == 2 ) {
-        if( _doubleClickShouldMinimize ) {
+    if (theEvent.locationInWindow.y >= (_window.frame.size.height - 59)) {
+      if (theEvent.clickCount == 2) {
+        if (_doubleClickShouldMinimize) {
           [_window miniaturize:self];
         } else {
           [_window zoom:self];
@@ -167,7 +167,7 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
 }
 
 - (IBAction)toggleStatusItem:(id)sender {
-    if( self.statusItem != nil ) {
+    if (self.statusItem != nil) {
       self.statusItem = nil;
       [self.statusItemToggle setTitle:@"Show Status Icon"];
       [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WAMShouldHideStatusItem];

--- a/WhatsMac/WAMApplication.m
+++ b/WhatsMac/WAMApplication.m
@@ -4,14 +4,14 @@
 @implementation WAMApplication
 - (void)sendEvent:(NSEvent *)theEvent {
     if (theEvent.type == NSLeftMouseUp) {
-      if( [((AppDelegate*)self.delegate) shouldPropagateMouseUpEvent:theEvent] ) {
+      if ([((AppDelegate*)self.delegate) shouldPropagateMouseUpEvent:theEvent]) {
         [super sendEvent:theEvent];
       }
       return;
     }
 
     if (theEvent.type == NSLeftMouseDragged) {
-      if( [((AppDelegate*)self.delegate) shouldPropagateMouseDraggedEvent:theEvent] ) {
+      if ([((AppDelegate*)self.delegate) shouldPropagateMouseDraggedEvent:theEvent]) {
         [super sendEvent:theEvent];
       }
       return;


### PR DESCRIPTION
This PR:

1. Reintroduced the ability to *Double Click In Titlebar to Zoom/Minimize**. (#54)
2. Fixed an issue preventing the traffic light from showing up in a circumstance. (#66)
3. Fixed the barely visible status item when using a dark menu bar. (#80)
4. Fixed a few lines with inconsistent code style that came with my previous commits. Sorry about that. :(

-
\* courtesy: https://bugzilla.mozilla.org/show_bug.cgi?id=853105, though as a side note the plist key has been changed for 10.10 and later.