### PR TITLE
Disable App Transport Security completely.

### DIFF
--- a/WhatsMac/Info.plist
+++ b/WhatsMac/Info.plist
@@ -26,16 +26,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>whatsapp.net</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Mac wrapper by Sam Stone and others, available under the MIT license. Contains Code from Messenger for Mac. WhatsApp Web by WhatsApp.</string>


### PR DESCRIPTION
It seems App Transport Security behaves inconsistently on different machines. So maybe we should just disable it entirely.

Related Issue: #81