### PR TITLE
Window reappears even if it was closed before.

### DIFF
--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -178,7 +178,7 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
     }
 }
 
-- (void)showAppWindow:(id)sender {
+- (IBAction)showAppWindow:(id)sender {
     if (![self.window isVisible]) {
         [self.window makeKeyAndOrderFront:nil];
     }

--- a/WhatsMac/AppDelegate.m
+++ b/WhatsMac/AppDelegate.m
@@ -179,6 +179,9 @@ NSString* const WAMShouldHideStatusItem = @"WAMShouldHideStatusItem";
 }
 
 - (void)showAppWindow:(id)sender {
+    if (![self.window isVisible]) {
+        [self.window makeKeyAndOrderFront:nil];
+    }
     [NSApp activateIgnoringOtherApps:YES];
 }
 

--- a/WhatsMac/MainMenu.xib
+++ b/WhatsMac/MainMenu.xib
@@ -30,12 +30,6 @@
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Hide Status Item" id="rhL-VI-tpz">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="toggleStatusItem:" target="dKU-pJ-OAl" id="5Rb-bX-Jxw"/>
-                                </connections>
-                            </menuItem>
                             <menuItem title="Check For Updates..." id="DqK-XA-zln">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -314,6 +308,13 @@
                         <items>
                             <menuItem title="Zoom In" keyEquivalent="+" id="snW-S8-Cw5"/>
                             <menuItem title="Zoom Out" keyEquivalent="-" id="1UK-8n-QPP"/>
+                            <menuItem isSeparatorItem="YES" id="Fai-Hq-7jX"/>
+                            <menuItem title="Hide Status Item" id="rhL-VI-tpz">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleStatusItem:" target="dKU-pJ-OAl" id="5Rb-bX-Jxw"/>
+                                </connections>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/WhatsMac/MainMenu.xib
+++ b/WhatsMac/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9052" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9052"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -342,6 +342,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="arrangeInFront:" target="-1" id="DRN-fu-gQh"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="UpI-Du-gAA"/>
+                            <menuItem title="ChitChat" keyEquivalent="0" id="Mzf-KT-boW">
+                                <connections>
+                                    <action selector="showAppWindow:" target="dKU-pJ-OAl" id="3rN-DA-Dlr"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
If the window was closed before and the status bar icon was clicked, the window did not appear again, as the app became first, but without actual window. I added a small change that checks if the window is visible and it not, it will be shown before the application gets to the foreground.
